### PR TITLE
Fix group node crashes, fixes #99

### DIFF
--- a/editor/model/HistoryList.cpp
+++ b/editor/model/HistoryList.cpp
@@ -4,18 +4,13 @@
 
 using namespace AxiomModel;
 
-HistoryList::HistoryList(CompileApplyer applyer) : applyCompile(std::move(applyer)) {}
-
-HistoryList::HistoryList(size_t stackPos, std::vector<std::unique_ptr<AxiomModel::Action>> stack,
-                         AxiomModel::HistoryList::CompileApplyer applyer)
-    : _stackPos(stackPos), _stack(std::move(stack)), applyCompile(std::move(applyer)) {}
+HistoryList::HistoryList(size_t stackPos, std::vector<std::unique_ptr<AxiomModel::Action>> stack)
+    : _stackPos(stackPos), _stack(std::move(stack)) {}
 
 void HistoryList::append(std::unique_ptr<AxiomModel::Action> action, bool forward) {
     // run the action forward
     if (forward) {
-        std::vector<QUuid> compileItems;
-        action->forward(true, compileItems);
-        applyCompile(std::move(compileItems));
+        action->forward(true);
     }
 
     // remove items ahead of where we are
@@ -46,9 +41,7 @@ void HistoryList::undo() {
 
     _stackPos--;
     auto undoAction = _stack[_stackPos].get();
-    std::vector<QUuid> compileItems;
-    undoAction->backward(compileItems);
-    applyCompile(std::move(compileItems));
+    undoAction->backward();
 
     stackChanged();
 }
@@ -67,10 +60,8 @@ void HistoryList::redo() {
 
     auto redoAction = _stack[_stackPos].get();
     std::vector<QUuid> compileItems;
-    redoAction->forward(false, compileItems);
+    redoAction->forward(false);
     _stackPos++;
-
-    applyCompile(std::move(compileItems));
 
     stackChanged();
 }

--- a/editor/model/HistoryList.h
+++ b/editor/model/HistoryList.h
@@ -23,11 +23,9 @@ namespace AxiomModel {
 
         size_t maxActions = 256;
 
-        using CompileApplyer = std::function<void(std::vector<QUuid>)>;
+        HistoryList() = default;
 
-        explicit HistoryList(CompileApplyer applyer);
-
-        HistoryList(size_t stackPos, std::vector<std::unique_ptr<Action>> stack, CompileApplyer applyer);
+        HistoryList(size_t stackPos, std::vector<std::unique_ptr<Action>> stack);
 
         const std::vector<std::unique_ptr<Action>> &stack() const { return _stack; }
 
@@ -47,11 +45,8 @@ namespace AxiomModel {
 
         void redo();
 
-        CompileApplyer &applyer() { return applyCompile; }
-
     private:
         size_t _stackPos = 0;
         std::vector<std::unique_ptr<Action>> _stack;
-        CompileApplyer applyCompile;
     };
 }

--- a/editor/model/ModelObject.cpp
+++ b/editor/model/ModelObject.cpp
@@ -18,14 +18,6 @@ AxiomCommon::BoxedSequence<ModelObject *> ModelObject::links() {
     return AxiomCommon::boxSequence(AxiomCommon::blank<ModelObject *>());
 }
 
-AxiomCommon::BoxedSequence<QUuid> ModelObject::deleteCompileLinks() {
-    return AxiomCommon::boxSequence(AxiomCommon::once(parentUuid()));
-}
-
-AxiomCommon::BoxedSequence<QUuid> ModelObject::compileLinks() {
-    return AxiomCommon::boxSequence(AxiomCommon::blank<QUuid>());
-}
-
 void ModelObject::remove() {
     removed();
     PoolObject::remove();

--- a/editor/model/ModelObject.h
+++ b/editor/model/ModelObject.h
@@ -29,6 +29,8 @@ namespace AxiomModel {
 
         ModelRoot *root() const { return _root; }
 
+        virtual QString debugName() = 0;
+
         bool isDirty() const { return _isDirty; }
 
         void clearDirty() { _isDirty = false; }

--- a/editor/model/ModelObject.h
+++ b/editor/model/ModelObject.h
@@ -29,6 +29,10 @@ namespace AxiomModel {
 
         ModelRoot *root() const { return _root; }
 
+        bool isDirty() const { return _isDirty; }
+
+        void clearDirty() { _isDirty = false; }
+
         virtual void saveState() {}
 
         virtual void restoreState() {}
@@ -37,16 +41,16 @@ namespace AxiomModel {
 
         virtual AxiomCommon::BoxedSequence<ModelObject *> links();
 
-        virtual AxiomCommon::BoxedSequence<QUuid> deleteCompileLinks();
-
-        virtual AxiomCommon::BoxedSequence<QUuid> compileLinks();
-
         virtual void build(MaximCompiler::Transaction *transaction) {}
 
         void remove() override;
 
+    protected:
+        void setDirty() { _isDirty = true; }
+
     private:
         ModelType _modelType;
         ModelRoot *_root;
+        bool _isDirty = true;
     };
 }

--- a/editor/model/ModelRoot.cpp
+++ b/editor/model/ModelRoot.cpp
@@ -41,7 +41,8 @@ void ModelRoot::attachRuntime(MaximCompiler::Runtime *runtime) {
     applyTransaction(std::move(buildTransaction));
 
     // clear the dirty state of everything, since we've just compiled them
-    for (const auto &obj : pool().sequence().sequence()) {
+    auto poolSequence = pool().sequence().sequence();
+    for (const auto &obj : poolSequence) {
         if (auto modelObj = dynamic_cast<ModelObject *>(obj)) {
             modelObj->clearDirty();
         }
@@ -62,7 +63,8 @@ void ModelRoot::applyDirtyItemsTo(MaximCompiler::Transaction *transaction) {
 
     // iterate over pool items in reverse order, since we need to compile children before parents
     size_t dirtyItemCount = 0;
-    for (auto rit = pool().objects().rbegin(); rit < pool().objects().rend(); rit++) {
+    const auto &poolObjects = pool().objects();
+    for (auto rit = poolObjects.rbegin(); rit < poolObjects.rend(); rit++) {
         auto obj = dynamic_cast<ModelObject *>(rit->get());
         if (obj && obj->isDirty()) {
             obj->clearDirty();

--- a/editor/model/ModelRoot.cpp
+++ b/editor/model/ModelRoot.cpp
@@ -55,6 +55,14 @@ void ModelRoot::applyDirtyItemsTo(MaximCompiler::Transaction *transaction) {
     for (auto rit = pool().objects().rbegin(); rit < pool().objects().rend(); rit++) {
         auto obj = dynamic_cast<ModelObject *>(rit->get());
         if (obj && obj->isDirty()) {
+            std::string parentObjName = "<root>";
+            if (!obj->parentUuid().isNull()) {
+                auto parentObj = dynamic_cast<ModelObject *>(find(pool().sequence().sequence(), obj->parentUuid()));
+                parentObjName = parentObj->debugName().toStdString();
+            }
+
+            std::cout << "Recompiling " << obj->debugName().toStdString() << " (in " << parentObjName << ")"
+                      << std::endl;
             obj->clearDirty();
             obj->build(transaction);
         }
@@ -62,9 +70,13 @@ void ModelRoot::applyDirtyItemsTo(MaximCompiler::Transaction *transaction) {
 }
 
 void ModelRoot::compileDirtyItems() {
+    std::cout << "Compiling dirty items..." << std::endl;
     MaximCompiler::Transaction transaction;
     applyDirtyItemsTo(&transaction);
+    std::cout << "Applied dirty items, transaction is now:" << std::endl;
+    transaction.printToStdout();
     applyTransaction(std::move(transaction));
+    std::cout << "Finished applying" << std::endl;
 
     modified();
 }

--- a/editor/model/ModelRoot.h
+++ b/editor/model/ModelRoot.h
@@ -74,9 +74,11 @@ namespace AxiomModel {
 
         std::lock_guard<std::mutex> lockRuntime();
 
-        void applyItemsTo(const std::vector<QUuid> &items, MaximCompiler::Transaction *transaction);
+        void setHistory(HistoryList history);
 
-        void applyCompile(const std::vector<QUuid> &items);
+        void applyDirtyItemsTo(MaximCompiler::Transaction *transaction);
+
+        void compileDirtyItems();
 
         void applyTransaction(MaximCompiler::Transaction transaction);
 

--- a/editor/model/Pool.h
+++ b/editor/model/Pool.h
@@ -30,12 +30,14 @@ namespace AxiomModel {
 
         std::unique_ptr<PoolObject> removeObj(PoolObject *obj);
 
+        const std::vector<std::unique_ptr<PoolObject>> &objects() const { return _objects; }
+
         Sequence sequence() { return AxiomCommon::refWatchSequence(&_sequence); }
 
         void destroy();
 
     private:
-        std::vector<std::unique_ptr<PoolObject>> objects;
+        std::vector<std::unique_ptr<PoolObject>> _objects;
         QHash<QUuid, PoolObject *> index;
         BaseSequence _sequence;
     };

--- a/editor/model/Project.cpp
+++ b/editor/model/Project.cpp
@@ -55,24 +55,23 @@ Project::Project(const AxiomBackend::DefaultConfiguration &defaultConfiguration)
             break;
         }
 
-        std::vector<QUuid> dummyItems;
         switch (portal.type) {
         case AxiomBackend::PortalType::INPUT:
             CreatePortalNodeAction::create(rootId, QPoint(-3, inputOffset), QString::fromStdString(portal.name),
                                            wireType, PortalControl::PortalType::INPUT, &mainRoot())
-                ->forward(true, dummyItems);
+                ->forward(true);
             inputOffset += portalSpacing;
             break;
         case AxiomBackend::PortalType::OUTPUT:
             CreatePortalNodeAction::create(rootId, QPoint(3, outputOffset), QString::fromStdString(portal.name),
                                            wireType, PortalControl::PortalType::OUTPUT, &mainRoot())
-                ->forward(true, dummyItems);
+                ->forward(true);
             outputOffset += portalSpacing;
             break;
         case AxiomBackend::PortalType::AUTOMATION:
             CreatePortalNodeAction::create(rootId, QPoint(0, automationOffset), QString::fromStdString(portal.name),
                                            wireType, PortalControl::PortalType::AUTOMATION, &mainRoot())
-                ->forward(true, dummyItems);
+                ->forward(true);
             automationOffset += portalSpacing;
             break;
         }

--- a/editor/model/actions/Action.h
+++ b/editor/model/actions/Action.h
@@ -51,9 +51,9 @@ namespace AxiomModel {
 
         ModelRoot *root() const { return _root; }
 
-        virtual void forward(bool first, std::vector<QUuid> &compileItems) = 0;
+        virtual void forward(bool first) = 0;
 
-        virtual void backward(std::vector<QUuid> &compileItems) = 0;
+        virtual void backward() = 0;
 
     private:
         ActionType _actionType;

--- a/editor/model/actions/AddGraphPointAction.cpp
+++ b/editor/model/actions/AddGraphPointAction.cpp
@@ -15,12 +15,12 @@ std::unique_ptr<AddGraphPointAction> AddGraphPointAction::create(const QUuid &co
     return std::make_unique<AddGraphPointAction>(controlUuid, index, time, val, root);
 }
 
-void AddGraphPointAction::forward(bool, std::vector<QUuid> &) {
+void AddGraphPointAction::forward(bool) {
     find(AxiomCommon::dynamicCast<GraphControl *>(root()->pool().sequence().sequence()), _controlUuid)
         ->insertPoint(_index, _time, _val, 0, 0);
 }
 
-void AddGraphPointAction::backward(std::vector<QUuid> &) {
+void AddGraphPointAction::backward() {
     find(AxiomCommon::dynamicCast<GraphControl *>(root()->pool().sequence().sequence()), _controlUuid)
         ->removePoint((uint8_t)(_index + 1));
 }

--- a/editor/model/actions/AddGraphPointAction.h
+++ b/editor/model/actions/AddGraphPointAction.h
@@ -13,9 +13,9 @@ namespace AxiomModel {
         static std::unique_ptr<AddGraphPointAction> create(const QUuid &controlUuid, uint8_t index, float time,
                                                            float val, ModelRoot *root);
 
-        void forward(bool first, std::vector<QUuid> &compileItems) override;
+        void forward(bool first) override;
 
-        void backward(std::vector<QUuid> &compileItems) override;
+        void backward() override;
 
         const QUuid &controlUuid() const { return _controlUuid; }
 

--- a/editor/model/actions/CompositeAction.cpp
+++ b/editor/model/actions/CompositeAction.cpp
@@ -10,14 +10,14 @@ std::unique_ptr<CompositeAction> CompositeAction::create(std::vector<std::unique
     return std::make_unique<CompositeAction>(std::move(actions), root);
 }
 
-void CompositeAction::forward(bool first, std::vector<QUuid> &compileItems) {
+void CompositeAction::forward(bool first) {
     for (const auto &action : _actions) {
-        action->forward(first, compileItems);
+        action->forward(first);
     }
 }
 
-void CompositeAction::backward(std::vector<QUuid> &compileItems) {
+void CompositeAction::backward() {
     for (auto i = _actions.end() - 1; i >= _actions.begin(); i--) {
-        (*i)->backward(compileItems);
+        (*i)->backward();
     }
 }

--- a/editor/model/actions/CompositeAction.h
+++ b/editor/model/actions/CompositeAction.h
@@ -12,9 +12,9 @@ namespace AxiomModel {
 
         static std::unique_ptr<CompositeAction> create(std::vector<std::unique_ptr<Action>> actions, ModelRoot *root);
 
-        void forward(bool first, std::vector<QUuid> &compileItems) override;
+        void forward(bool first) override;
 
-        void backward(std::vector<QUuid> &compileItems) override;
+        void backward() override;
 
         std::vector<std::unique_ptr<Action>> &actions() { return _actions; }
 

--- a/editor/model/actions/CreateConnectionAction.cpp
+++ b/editor/model/actions/CreateConnectionAction.cpp
@@ -24,12 +24,10 @@ std::unique_ptr<CreateConnectionAction> CreateConnectionAction::create(const QUu
     return create(QUuid::createUuid(), parentUuid, controlA, controlB, root);
 }
 
-void CreateConnectionAction::forward(bool, std::vector<QUuid> &compileItems) {
+void CreateConnectionAction::forward(bool) {
     root()->pool().registerObj(Connection::create(_uuid, _parentUuid, _controlA, _controlB, root()));
-    compileItems.push_back(_parentUuid);
 }
 
-void CreateConnectionAction::backward(std::vector<QUuid> &compileItems) {
+void CreateConnectionAction::backward() {
     find(root()->connections().sequence(), _uuid)->remove();
-    compileItems.push_back(_parentUuid);
 }

--- a/editor/model/actions/CreateConnectionAction.h
+++ b/editor/model/actions/CreateConnectionAction.h
@@ -18,9 +18,9 @@ namespace AxiomModel {
         static std::unique_ptr<CreateConnectionAction> create(const QUuid &parentUuid, const QUuid &controlA,
                                                               const QUuid &controlB, ModelRoot *root);
 
-        void forward(bool first, std::vector<QUuid> &compileItems) override;
+        void forward(bool first) override;
 
-        void backward(std::vector<QUuid> &compileItems) override;
+        void backward() override;
 
         const QUuid &uuid() const { return _uuid; }
 

--- a/editor/model/actions/CreateControlAction.cpp
+++ b/editor/model/actions/CreateControlAction.cpp
@@ -37,11 +37,11 @@ std::unique_ptr<CompositeAction> CreateControlAction::create(const QUuid &parent
     return std::move(prepareData.preActions);
 }
 
-void CreateControlAction::forward(bool, std::vector<QUuid> &) {
+void CreateControlAction::forward(bool) {
     root()->pool().registerObj(
         Control::createDefault(_type, _uuid, _parentUuid, _name, QUuid(), _pos, _size, _isWrittenTo, root()));
 }
 
-void CreateControlAction::backward(std::vector<QUuid> &) {
+void CreateControlAction::backward() {
     find(root()->controls().sequence(), _uuid)->remove();
 }

--- a/editor/model/actions/CreateControlAction.h
+++ b/editor/model/actions/CreateControlAction.h
@@ -25,9 +25,9 @@ namespace AxiomModel {
         static std::unique_ptr<CompositeAction> create(const QUuid &parentUuid, Control::ControlType type, QString name,
                                                        bool isWrittenTo, ModelRoot *root);
 
-        void forward(bool first, std::vector<QUuid> &compileItems) override;
+        void forward(bool first) override;
 
-        void backward(std::vector<QUuid> &compileItems) override;
+        void backward() override;
 
         const QUuid &uuid() const { return _uuid; }
 

--- a/editor/model/actions/CreateCustomNodeAction.cpp
+++ b/editor/model/actions/CreateCustomNodeAction.cpp
@@ -25,17 +25,12 @@ std::unique_ptr<CreateCustomNodeAction> CreateCustomNodeAction::create(const QUu
     return create(QUuid::createUuid(), parentUuid, pos, std::move(name), QUuid::createUuid(), root);
 }
 
-void CreateCustomNodeAction::forward(bool, std::vector<QUuid> &compileItems) {
+void CreateCustomNodeAction::forward(bool) {
     root()->pool().registerObj(CustomNode::create(_uuid, _parentUuid, _pos, QSize(3, 2), false, _name, _controlsUuid,
                                                   "", false, CustomNode::minPanelHeight, root()));
     root()->pool().registerObj(ControlSurface::create(_controlsUuid, _uuid, root()));
-
-    compileItems.push_back(_uuid);
-    compileItems.push_back(_parentUuid);
 }
 
-void CreateCustomNodeAction::backward(std::vector<QUuid> &compileItems) {
+void CreateCustomNodeAction::backward() {
     find(root()->nodes().sequence(), _uuid)->remove();
-
-    compileItems.push_back(_parentUuid);
 }

--- a/editor/model/actions/CreateCustomNodeAction.h
+++ b/editor/model/actions/CreateCustomNodeAction.h
@@ -19,9 +19,9 @@ namespace AxiomModel {
         static std::unique_ptr<CreateCustomNodeAction> create(const QUuid &parentUuid, QPoint pos, QString name,
                                                               ModelRoot *root);
 
-        void forward(bool first, std::vector<QUuid> &compileItems) override;
+        void forward(bool first) override;
 
-        void backward(std::vector<QUuid> &compileItems) override;
+        void backward() override;
 
         const QUuid &uuid() const { return _uuid; }
 

--- a/editor/model/actions/CreateGroupNodeAction.cpp
+++ b/editor/model/actions/CreateGroupNodeAction.cpp
@@ -27,18 +27,13 @@ std::unique_ptr<CreateGroupNodeAction> CreateGroupNodeAction::create(const QUuid
                   root);
 }
 
-void CreateGroupNodeAction::forward(bool, std::vector<QUuid> &compileItems) {
+void CreateGroupNodeAction::forward(bool) {
     root()->pool().registerObj(
         GroupNode::create(_uuid, _parentUuid, _pos, QSize(3, 2), false, _name, _controlsUuid, _innerUuid, root()));
     root()->pool().registerObj(ControlSurface::create(_controlsUuid, _uuid, root()));
     root()->pool().registerObj(GroupSurface::create(_innerUuid, _uuid, QPoint(0, 0), 0, root()));
-
-    compileItems.push_back(_innerUuid);
-    compileItems.push_back(_parentUuid);
 }
 
-void CreateGroupNodeAction::backward(std::vector<QUuid> &compileItems) {
+void CreateGroupNodeAction::backward() {
     find(root()->nodes().sequence(), _uuid)->remove();
-
-    compileItems.push_back(_parentUuid);
 }

--- a/editor/model/actions/CreateGroupNodeAction.h
+++ b/editor/model/actions/CreateGroupNodeAction.h
@@ -20,9 +20,9 @@ namespace AxiomModel {
         static std::unique_ptr<CreateGroupNodeAction> create(const QUuid &parentUuid, QPoint pos, QString name,
                                                              ModelRoot *root);
 
-        void forward(bool first, std::vector<QUuid> &compileItems) override;
+        void forward(bool first) override;
 
-        void backward(std::vector<QUuid> &compileItems) override;
+        void backward() override;
 
         const QUuid &uuid() const { return _uuid; }
 

--- a/editor/model/actions/CreatePortalNodeAction.cpp
+++ b/editor/model/actions/CreatePortalNodeAction.cpp
@@ -37,19 +37,15 @@ std::unique_ptr<CreatePortalNodeAction> CreatePortalNodeAction::create(const QUu
                   portalId, QUuid::createUuid(), root);
 }
 
-void CreatePortalNodeAction::forward(bool, std::vector<QUuid> &compileItems) {
+void CreatePortalNodeAction::forward(bool) {
     root()->pool().registerObj(
         PortalNode::create(_uuid, _parentUuid, _pos, QSize(1, 1), false, _name, _controlsUuid, root()));
     root()->pool().registerObj(ControlSurface::create(_controlsUuid, _uuid, root()));
     root()->pool().registerObj(PortalControl::create(_controlUuid, _controlsUuid, QPoint(0, 0), QSize(2, 2), false, "",
                                                      false, QUuid(), QUuid(), _wireType, _portalType, _portalId,
                                                      root()));
-
-    compileItems.push_back(_parentUuid);
 }
 
-void CreatePortalNodeAction::backward(std::vector<QUuid> &compileItems) {
+void CreatePortalNodeAction::backward() {
     find(root()->nodes().sequence(), _uuid)->remove();
-
-    compileItems.push_back(_parentUuid);
 }

--- a/editor/model/actions/CreatePortalNodeAction.h
+++ b/editor/model/actions/CreatePortalNodeAction.h
@@ -23,9 +23,9 @@ namespace AxiomModel {
                                                               ConnectionWire::WireType wireType,
                                                               PortalControl::PortalType portalType, ModelRoot *root);
 
-        void forward(bool first, std::vector<QUuid> &compileItems) override;
+        void forward(bool first) override;
 
-        void backward(std::vector<QUuid> &compileItems) override;
+        void backward() override;
 
         const QUuid &uuid() const { return _uuid; }
 

--- a/editor/model/actions/DeleteGraphPointAction.cpp
+++ b/editor/model/actions/DeleteGraphPointAction.cpp
@@ -17,12 +17,12 @@ std::unique_ptr<DeleteGraphPointAction> DeleteGraphPointAction::create(const QUu
     return std::make_unique<DeleteGraphPointAction>(controlUuid, index, time, val, tension, state, root);
 }
 
-void DeleteGraphPointAction::forward(bool, std::vector<QUuid> &) {
+void DeleteGraphPointAction::forward(bool) {
     find(AxiomCommon::dynamicCast<GraphControl *>(root()->pool().sequence().sequence()), _controlUuid)
         ->removePoint(_index);
 }
 
-void DeleteGraphPointAction::backward(std::vector<QUuid> &) {
+void DeleteGraphPointAction::backward() {
     find(AxiomCommon::dynamicCast<GraphControl *>(root()->pool().sequence().sequence()), _controlUuid)
         ->insertPoint((uint8_t)(_index - 1), _time, _val, _tension, _state);
 }

--- a/editor/model/actions/DeleteGraphPointAction.h
+++ b/editor/model/actions/DeleteGraphPointAction.h
@@ -14,9 +14,9 @@ namespace AxiomModel {
         static std::unique_ptr<DeleteGraphPointAction> create(const QUuid &controlUuid, uint8_t index, float time,
                                                               float val, float tension, uint8_t state, ModelRoot *root);
 
-        void forward(bool first, std::vector<QUuid> &compileItems) override;
+        void forward(bool first) override;
 
-        void backward(std::vector<QUuid> &compileItems) override;
+        void backward() override;
 
         const QUuid &controlUuid() const { return _controlUuid; }
 

--- a/editor/model/actions/DeleteObjectAction.h
+++ b/editor/model/actions/DeleteObjectAction.h
@@ -18,9 +18,9 @@ namespace AxiomModel {
 
         static std::unique_ptr<DeleteObjectAction> create(const QUuid &uuid, AxiomModel::ModelRoot *root);
 
-        void forward(bool first, std::vector<QUuid> &compileItems) override;
+        void forward(bool first) override;
 
-        void backward(std::vector<QUuid> &compileItems) override;
+        void backward() override;
 
         const QUuid &uuid() const { return _uuid; }
 

--- a/editor/model/actions/ExposeControlAction.cpp
+++ b/editor/model/actions/ExposeControlAction.cpp
@@ -38,7 +38,7 @@ std::unique_ptr<CompositeAction> ExposeControlAction::create(const QUuid &contro
     return std::move(prepareData.preActions);
 }
 
-void ExposeControlAction::forward(bool, std::vector<QUuid> &compileItems) {
+void ExposeControlAction::forward(bool) {
     auto controlToExpose = find(root()->controls().sequence(), _controlUuid);
     controlToExpose->setExposerUuid(_exposeUuid);
     auto controlSurface = dynamic_cast<GroupSurface *>(controlToExpose->surface()->node()->surface());
@@ -50,20 +50,9 @@ void ExposeControlAction::forward(bool, std::vector<QUuid> &compileItems) {
     auto newControl = Control::createDefault(controlToExpose->controlType(), _exposeUuid, exposeSurface->uuid(),
                                              controlToExpose->name(), _controlUuid, _pos, _size, isWrittenTo, root());
     root()->pool().registerObj(std::move(newControl));
-
-    compileItems.push_back(controlSurface->uuid());
-    compileItems.push_back(exposeNode->surface()->uuid());
 }
 
-void ExposeControlAction::backward(std::vector<QUuid> &compileItems) {
-    auto innerControl = find(root()->controls().sequence(), _controlUuid);
-    auto innerSurface = innerControl->surface()->node()->surface();
-
+void ExposeControlAction::backward() {
     auto exposedControl = find(root()->controls().sequence(), _exposeUuid);
-    auto exposeSurface = exposedControl->surface()->node()->surface();
-
     exposedControl->remove();
-
-    compileItems.push_back(innerSurface->uuid());
-    compileItems.push_back(exposeSurface->uuid());
 }

--- a/editor/model/actions/ExposeControlAction.h
+++ b/editor/model/actions/ExposeControlAction.h
@@ -22,9 +22,9 @@ namespace AxiomModel {
 
         static std::unique_ptr<CompositeAction> create(const QUuid &controlUuid, ModelRoot *root);
 
-        void forward(bool first, std::vector<QUuid> &compileItems) override;
+        void forward(bool first) override;
 
-        void backward(std::vector<QUuid> &compileItems) override;
+        void backward() override;
 
         const QUuid &controlUuid() const { return _controlUuid; }
 

--- a/editor/model/actions/GridItemMoveAction.cpp
+++ b/editor/model/actions/GridItemMoveAction.cpp
@@ -15,10 +15,10 @@ std::unique_ptr<GridItemMoveAction> GridItemMoveAction::create(const QUuid &uuid
     return std::make_unique<GridItemMoveAction>(uuid, beforePos, afterPos, root);
 }
 
-void GridItemMoveAction::forward(bool, std::vector<QUuid> &) {
+void GridItemMoveAction::forward(bool) {
     find(AxiomCommon::dynamicCast<GridItem *>(root()->pool().sequence().sequence()), _uuid)->setPos(_afterPos);
 }
 
-void GridItemMoveAction::backward(std::vector<QUuid> &) {
+void GridItemMoveAction::backward() {
     find(AxiomCommon::dynamicCast<GridItem *>(root()->pool().sequence().sequence()), _uuid)->setPos(_beforePos);
 }

--- a/editor/model/actions/GridItemMoveAction.h
+++ b/editor/model/actions/GridItemMoveAction.h
@@ -14,9 +14,9 @@ namespace AxiomModel {
         static std::unique_ptr<GridItemMoveAction> create(const QUuid &uuid, QPoint beforePos, QPoint afterPos,
                                                           AxiomModel::ModelRoot *root);
 
-        void forward(bool first, std::vector<QUuid> &compileItems) override;
+        void forward(bool first) override;
 
-        void backward(std::vector<QUuid> &compileItems) override;
+        void backward() override;
 
         const QUuid &uuid() const { return _uuid; }
 

--- a/editor/model/actions/GridItemSizeAction.cpp
+++ b/editor/model/actions/GridItemSizeAction.cpp
@@ -15,10 +15,10 @@ std::unique_ptr<GridItemSizeAction> GridItemSizeAction::create(const QUuid &uuid
     return std::make_unique<GridItemSizeAction>(uuid, beforeRect, afterRect, root);
 }
 
-void GridItemSizeAction::forward(bool, std::vector<QUuid> &) {
+void GridItemSizeAction::forward(bool) {
     find(AxiomCommon::dynamicCast<GridItem *>(root()->pool().sequence().sequence()), _uuid)->setRect(_afterRect);
 }
 
-void GridItemSizeAction::backward(std::vector<QUuid> &) {
+void GridItemSizeAction::backward() {
     find(AxiomCommon::dynamicCast<GridItem *>(root()->pool().sequence().sequence()), _uuid)->setRect(_beforeRect);
 }

--- a/editor/model/actions/GridItemSizeAction.h
+++ b/editor/model/actions/GridItemSizeAction.h
@@ -14,9 +14,9 @@ namespace AxiomModel {
         static std::unique_ptr<GridItemSizeAction> create(const QUuid &uuid, QRect beforeRect, QRect afterRect,
                                                           ModelRoot *root);
 
-        void forward(bool first, std::vector<QUuid> &compileItems) override;
+        void forward(bool first) override;
 
-        void backward(std::vector<QUuid> &compileItems) override;
+        void backward() override;
 
         const QUuid &uuid() const { return _uuid; }
 

--- a/editor/model/actions/MoveGraphPointAction.cpp
+++ b/editor/model/actions/MoveGraphPointAction.cpp
@@ -17,12 +17,12 @@ std::unique_ptr<MoveGraphPointAction> MoveGraphPointAction::create(const QUuid &
     return std::make_unique<MoveGraphPointAction>(controlUuid, index, oldTime, oldValue, newTime, newValue, root);
 }
 
-void MoveGraphPointAction::forward(bool, std::vector<QUuid> &) {
+void MoveGraphPointAction::forward(bool) {
     find(AxiomCommon::dynamicCast<GraphControl *>(root()->pool().sequence().sequence()), _controlUuid)
         ->movePoint(_index, _newTime, _newValue);
 }
 
-void MoveGraphPointAction::backward(std::vector<QUuid> &compileItems) {
+void MoveGraphPointAction::backward() {
     find(AxiomCommon::dynamicCast<GraphControl *>(root()->pool().sequence().sequence()), _controlUuid)
         ->movePoint(_index, _oldTime, _oldValue);
 }

--- a/editor/model/actions/MoveGraphPointAction.h
+++ b/editor/model/actions/MoveGraphPointAction.h
@@ -15,9 +15,9 @@ namespace AxiomModel {
                                                             float oldValue, float newTime, float newValue,
                                                             ModelRoot *root);
 
-        void forward(bool first, std::vector<QUuid> &compileItems) override;
+        void forward(bool first) override;
 
-        void backward(std::vector<QUuid> &compileItems) override;
+        void backward() override;
 
         const QUuid &controlUuid() const { return _controlUuid; }
 

--- a/editor/model/actions/PasteBufferAction.cpp
+++ b/editor/model/actions/PasteBufferAction.cpp
@@ -29,7 +29,7 @@ std::unique_ptr<PasteBufferAction> PasteBufferAction::create(const QUuid &surfac
     return create(surfaceUuid, false, std::move(buffer), QVector<QUuid>(), center, root);
 }
 
-void PasteBufferAction::forward(bool, std::vector<QUuid> &compileItems) {
+void PasteBufferAction::forward(bool) {
     assert(!_buffer.isEmpty());
     assert(_usedUuids.isEmpty());
 
@@ -62,15 +62,9 @@ void PasteBufferAction::forward(bool, std::vector<QUuid> &compileItems) {
         }
         _usedUuids.push_back(obj->uuid());
     }
-
-    std::reverse(used.begin(), used.end());
-    for (const auto &obj : used) {
-        compileItems.push_back(obj->uuid());
-        compileItems.push_back(obj->parentUuid());
-    }
 }
 
-void PasteBufferAction::backward(std::vector<QUuid> &compileItems) {
+void PasteBufferAction::backward() {
     assert(_buffer.isEmpty());
     assert(!_usedUuids.isEmpty());
 
@@ -96,9 +90,5 @@ void PasteBufferAction::backward(std::vector<QUuid> &compileItems) {
 
     while (!objs.empty()) {
         (*objs.begin())->remove();
-    }
-
-    for (const auto &id : parentIds) {
-        compileItems.push_back(id);
     }
 }

--- a/editor/model/actions/PasteBufferAction.h
+++ b/editor/model/actions/PasteBufferAction.h
@@ -21,9 +21,9 @@ namespace AxiomModel {
         static std::unique_ptr<PasteBufferAction> create(const QUuid &surfaceUuid, QByteArray buffer, QPoint center,
                                                          ModelRoot *root);
 
-        void forward(bool first, std::vector<QUuid> &compileItems) override;
+        void forward(bool first) override;
 
-        void backward(std::vector<QUuid> &compileItems) override;
+        void backward() override;
 
         const QUuid &surfaceUuid() const { return _surfaceUuid; }
 

--- a/editor/model/actions/RenameControlAction.cpp
+++ b/editor/model/actions/RenameControlAction.cpp
@@ -16,10 +16,10 @@ std::unique_ptr<RenameControlAction> RenameControlAction::create(const QUuid &uu
     return std::make_unique<RenameControlAction>(uuid, std::move(oldName), std::move(newName), root);
 }
 
-void RenameControlAction::forward(bool, std::vector<QUuid> &compileItems) {
+void RenameControlAction::forward(bool) {
     find(root()->controls().sequence(), _uuid)->setName(_newName);
 }
 
-void RenameControlAction::backward(std::vector<QUuid> &compileItems) {
+void RenameControlAction::backward() {
     find(root()->controls().sequence(), _uuid)->setName(_oldName);
 }

--- a/editor/model/actions/RenameControlAction.h
+++ b/editor/model/actions/RenameControlAction.h
@@ -13,9 +13,9 @@ namespace AxiomModel {
         static std::unique_ptr<RenameControlAction> create(const QUuid &uuid, QString oldName, QString newName,
                                                            ModelRoot *root);
 
-        void forward(bool first, std::vector<QUuid> &compileItems) override;
+        void forward(bool first) override;
 
-        void backward(std::vector<QUuid> &compileItems) override;
+        void backward() override;
 
         const QUuid &uuid() const { return _uuid; }
 

--- a/editor/model/actions/RenameNodeAction.cpp
+++ b/editor/model/actions/RenameNodeAction.cpp
@@ -14,10 +14,10 @@ std::unique_ptr<RenameNodeAction> RenameNodeAction::create(const QUuid &uuid, QS
     return std::make_unique<RenameNodeAction>(uuid, std::move(oldName), std::move(newName), root);
 }
 
-void RenameNodeAction::forward(bool, std::vector<QUuid> &) {
+void RenameNodeAction::forward(bool) {
     find(root()->nodes().sequence(), _uuid)->setName(_newName);
 }
 
-void RenameNodeAction::backward(std::vector<QUuid> &) {
+void RenameNodeAction::backward() {
     find(root()->nodes().sequence(), _uuid)->setName(_oldName);
 }

--- a/editor/model/actions/RenameNodeAction.h
+++ b/editor/model/actions/RenameNodeAction.h
@@ -14,9 +14,9 @@ namespace AxiomModel {
         static std::unique_ptr<RenameNodeAction> create(const QUuid &uuid, QString oldName, QString newName,
                                                         ModelRoot *root);
 
-        void forward(bool first, std::vector<QUuid> &compileItems) override;
+        void forward(bool first) override;
 
-        void backward(std::vector<QUuid> &compileItems) override;
+        void backward() override;
 
         const QUuid &uuid() const { return _uuid; }
 

--- a/editor/model/actions/SetCodeAction.cpp
+++ b/editor/model/actions/SetCodeAction.cpp
@@ -19,26 +19,20 @@ std::unique_ptr<SetCodeAction> SetCodeAction::create(const QUuid &uuid, QString 
                                            root);
 }
 
-void SetCodeAction::forward(bool first, std::vector<QUuid> &compileItems) {
+void SetCodeAction::forward(bool first) {
     auto node = find(AxiomCommon::dynamicCast<CustomNode *>(root()->nodes().sequence()), _uuid);
     node->setCode(_newCode);
 
-    compileItems.push_back(node->uuid());
-    compileItems.push_back(node->surface()->uuid());
     for (const auto &action : _controlActions) {
-        action->forward(first, compileItems);
+        action->forward(first);
     }
 }
 
-void SetCodeAction::backward(std::vector<QUuid> &compileItems) {
+void SetCodeAction::backward() {
     auto node = find(AxiomCommon::dynamicCast<CustomNode *>(root()->nodes().sequence()), _uuid);
     node->setCode(_oldCode);
 
-    compileItems.push_back(node->uuid());
-    compileItems.push_back(node->surface()->uuid());
-    if (!_controlActions.empty()) {
-        for (auto i = _controlActions.end() - 1; i >= _controlActions.begin(); i--) {
-            (*i)->backward(compileItems);
-        }
+    for (auto rit = _controlActions.rbegin(); rit < _controlActions.rend(); rit++) {
+        (*rit)->backward();
     }
 }

--- a/editor/model/actions/SetCodeAction.h
+++ b/editor/model/actions/SetCodeAction.h
@@ -16,9 +16,9 @@ namespace AxiomModel {
                                                      std::vector<std::unique_ptr<Action>> controlActions,
                                                      ModelRoot *root);
 
-        void forward(bool first, std::vector<QUuid> &compileItems) override;
+        void forward(bool first) override;
 
-        void backward(std::vector<QUuid> &compileItems) override;
+        void backward() override;
 
         const QUuid &uuid() const { return _uuid; }
 

--- a/editor/model/actions/SetGraphTagAction.cpp
+++ b/editor/model/actions/SetGraphTagAction.cpp
@@ -16,12 +16,12 @@ std::unique_ptr<SetGraphTagAction> SetGraphTagAction::create(const QUuid &contro
     return std::make_unique<SetGraphTagAction>(controlUuid, index, oldTag, newTag, root);
 }
 
-void SetGraphTagAction::forward(bool, std::vector<QUuid> &) {
+void SetGraphTagAction::forward(bool) {
     find(AxiomCommon::dynamicCast<GraphControl *>(root()->pool().sequence().sequence()), _controlUuid)
         ->setPointTag(_index, _newTag);
 }
 
-void SetGraphTagAction::backward(std::vector<QUuid> &compileItems) {
+void SetGraphTagAction::backward() {
     find(AxiomCommon::dynamicCast<GraphControl *>(root()->pool().sequence().sequence()), _controlUuid)
         ->setPointTag(_index, _oldTag);
 }

--- a/editor/model/actions/SetGraphTagAction.h
+++ b/editor/model/actions/SetGraphTagAction.h
@@ -13,9 +13,9 @@ namespace AxiomModel {
         static std::unique_ptr<SetGraphTagAction> create(const QUuid &controlUuid, uint8_t index, uint8_t oldTag,
                                                          uint8_t newTag, ModelRoot *root);
 
-        void forward(bool first, std::vector<QUuid> &compileItems) override;
+        void forward(bool first) override;
 
-        void backward(std::vector<QUuid> &compileItems) override;
+        void backward() override;
 
         const QUuid &controlUuid() const { return _controlUuid; }
 

--- a/editor/model/actions/SetGraphTensionAction.cpp
+++ b/editor/model/actions/SetGraphTensionAction.cpp
@@ -17,12 +17,12 @@ std::unique_ptr<SetGraphTensionAction> SetGraphTensionAction::create(const QUuid
     return std::make_unique<SetGraphTensionAction>(controlUuid, index, oldTension, newTension, root);
 }
 
-void SetGraphTensionAction::forward(bool, std::vector<QUuid> &) {
+void SetGraphTensionAction::forward(bool) {
     find(AxiomCommon::dynamicCast<GraphControl *>(root()->pool().sequence().sequence()), _controlUuid)
         ->setCurveTension(_index, _newTension);
 }
 
-void SetGraphTensionAction::backward(std::vector<QUuid> &) {
+void SetGraphTensionAction::backward() {
     find(AxiomCommon::dynamicCast<GraphControl *>(root()->pool().sequence().sequence()), _controlUuid)
         ->setCurveTension(_index, _oldTension);
 }

--- a/editor/model/actions/SetGraphTensionAction.h
+++ b/editor/model/actions/SetGraphTensionAction.h
@@ -14,9 +14,9 @@ namespace AxiomModel {
         static std::unique_ptr<SetGraphTensionAction> create(const QUuid &controlUuid, uint8_t index, float oldTension,
                                                              float newTension, ModelRoot *root);
 
-        void forward(bool first, std::vector<QUuid> &compileItems) override;
+        void forward(bool first) override;
 
-        void backward(std::vector<QUuid> &compileItems) override;
+        void backward() override;
 
         const QUuid &controlUuid() const { return _controlUuid; }
 

--- a/editor/model/actions/SetNumModeAction.cpp
+++ b/editor/model/actions/SetNumModeAction.cpp
@@ -16,10 +16,10 @@ std::unique_ptr<SetNumModeAction> SetNumModeAction::create(const QUuid &uuid,
     return std::make_unique<SetNumModeAction>(uuid, beforeMode, afterMode, root);
 }
 
-void SetNumModeAction::forward(bool, std::vector<QUuid> &) {
+void SetNumModeAction::forward(bool) {
     find(AxiomCommon::dynamicCast<NumControl *>(root()->controls().sequence()), _uuid)->setDisplayMode(_afterMode);
 }
 
-void SetNumModeAction::backward(std::vector<QUuid> &) {
+void SetNumModeAction::backward() {
     find(AxiomCommon::dynamicCast<NumControl *>(root()->controls().sequence()), _uuid)->setDisplayMode(_beforeMode);
 }

--- a/editor/model/actions/SetNumModeAction.h
+++ b/editor/model/actions/SetNumModeAction.h
@@ -15,9 +15,9 @@ namespace AxiomModel {
         static std::unique_ptr<SetNumModeAction> create(const QUuid &uuid, NumControl::DisplayMode beforeMode,
                                                         NumControl::DisplayMode afterMode, ModelRoot *root);
 
-        void forward(bool first, std::vector<QUuid> &compileItems) override;
+        void forward(bool first) override;
 
-        void backward(std::vector<QUuid> &compileItems) override;
+        void backward() override;
 
         const QUuid &uuid() const { return _uuid; }
 

--- a/editor/model/actions/SetNumRangeAction.cpp
+++ b/editor/model/actions/SetNumRangeAction.cpp
@@ -18,12 +18,12 @@ std::unique_ptr<SetNumRangeAction> SetNumRangeAction::create(const QUuid &uuid, 
                                                root);
 }
 
-void SetNumRangeAction::forward(bool, std::vector<QUuid> &) {
+void SetNumRangeAction::forward(bool) {
     find(AxiomCommon::dynamicCast<NumControl *>(root()->controls().sequence()), _uuid)
         ->setRange(_afterMin, _afterMax, _afterStep);
 }
 
-void SetNumRangeAction::backward(std::vector<QUuid> &) {
+void SetNumRangeAction::backward() {
     find(AxiomCommon::dynamicCast<NumControl *>(root()->controls().sequence()), _uuid)
         ->setRange(_beforeMin, _beforeMax, _beforeStep);
 }

--- a/editor/model/actions/SetNumRangeAction.h
+++ b/editor/model/actions/SetNumRangeAction.h
@@ -15,9 +15,9 @@ namespace AxiomModel {
                                                          uint32_t beforeStep, float afterMin, float afterMax,
                                                          uint32_t afterStep, ModelRoot *root);
 
-        void forward(bool first, std::vector<QUuid> &compileItems) override;
+        void forward(bool first) override;
 
-        void backward(std::vector<QUuid> &compileItems) override;
+        void backward() override;
 
         const QUuid &uuid() const { return _uuid; }
 

--- a/editor/model/actions/SetNumValueAction.cpp
+++ b/editor/model/actions/SetNumValueAction.cpp
@@ -15,10 +15,10 @@ std::unique_ptr<SetNumValueAction> SetNumValueAction::create(const QUuid &uuid, 
     return std::make_unique<SetNumValueAction>(uuid, beforeVal, afterVal, root);
 }
 
-void SetNumValueAction::forward(bool, std::vector<QUuid> &) {
+void SetNumValueAction::forward(bool) {
     find(AxiomCommon::dynamicCast<NumControl *>(root()->controls().sequence()), _uuid)->setValue(_afterVal);
 }
 
-void SetNumValueAction::backward(std::vector<QUuid> &) {
+void SetNumValueAction::backward() {
     find(AxiomCommon::dynamicCast<NumControl *>(root()->controls().sequence()), _uuid)->setValue(_beforeVal);
 }

--- a/editor/model/actions/SetNumValueAction.h
+++ b/editor/model/actions/SetNumValueAction.h
@@ -14,9 +14,9 @@ namespace AxiomModel {
         static std::unique_ptr<SetNumValueAction> create(const QUuid &uuid, NumValue beforeVal, NumValue afterVal,
                                                          ModelRoot *root);
 
-        void forward(bool first, std::vector<QUuid> &compileItems) override;
+        void forward(bool first) override;
 
-        void backward(std::vector<QUuid> &compileItems) override;
+        void backward() override;
 
         const QUuid &uuid() const { return _uuid; }
 

--- a/editor/model/actions/SetShowNameAction.cpp
+++ b/editor/model/actions/SetShowNameAction.cpp
@@ -14,10 +14,10 @@ std::unique_ptr<SetShowNameAction> SetShowNameAction::create(const QUuid &uuid, 
     return std::make_unique<SetShowNameAction>(uuid, beforeVal, afterVal, root);
 }
 
-void SetShowNameAction::forward(bool first, std::vector<QUuid> &) {
+void SetShowNameAction::forward(bool first) {
     find(root()->controls().sequence(), _uuid)->setShowName(_afterVal);
 }
 
-void SetShowNameAction::backward(std::vector<QUuid> &) {
+void SetShowNameAction::backward() {
     find(root()->controls().sequence(), _uuid)->setShowName(_beforeVal);
 }

--- a/editor/model/actions/SetShowNameAction.h
+++ b/editor/model/actions/SetShowNameAction.h
@@ -13,9 +13,9 @@ namespace AxiomModel {
         static std::unique_ptr<SetShowNameAction> create(const QUuid &uuid, bool beforeVal, bool afterVal,
                                                          ModelRoot *root);
 
-        void forward(bool first, std::vector<QUuid> &compileItems) override;
+        void forward(bool first) override;
 
-        void backward(std::vector<QUuid> &compileItems) override;
+        void backward() override;
 
         const QUuid &uuid() const { return _uuid; }
 

--- a/editor/model/actions/UnexposeControlAction.cpp
+++ b/editor/model/actions/UnexposeControlAction.cpp
@@ -25,16 +25,10 @@ std::unique_ptr<UnexposeControlAction> UnexposeControlAction::create(const QUuid
     return create(controlUuid, DeleteObjectAction::create(control->exposerUuid(), root), root);
 }
 
-void UnexposeControlAction::forward(bool first, std::vector<QUuid> &compileItems) {
-    auto control = find(root()->controls().sequence(), _controlUuid);
-    compileItems.push_back(control->surface()->node()->parentUuid());
-
-    _deleteExposerAction->forward(first, compileItems);
+void UnexposeControlAction::forward(bool first) {
+    _deleteExposerAction->forward(first);
 }
 
-void UnexposeControlAction::backward(std::vector<QUuid> &compileItems) {
-    auto control = find(root()->controls().sequence(), _controlUuid);
-    compileItems.push_back(control->surface()->node()->parentUuid());
-
-    _deleteExposerAction->backward(compileItems);
+void UnexposeControlAction::backward() {
+    _deleteExposerAction->backward();
 }

--- a/editor/model/actions/UnexposeControlAction.h
+++ b/editor/model/actions/UnexposeControlAction.h
@@ -16,9 +16,9 @@ namespace AxiomModel {
 
         static std::unique_ptr<UnexposeControlAction> create(const QUuid &controlUuid, ModelRoot *root);
 
-        void forward(bool first, std::vector<QUuid> &compileItems) override;
+        void forward(bool first) override;
 
-        void backward(std::vector<QUuid> &compileItems) override;
+        void backward() override;
 
         const QUuid &controlUuid() const { return _controlUuid; }
 

--- a/editor/model/objects/Connection.cpp
+++ b/editor/model/objects/Connection.cpp
@@ -48,6 +48,11 @@ std::unique_ptr<Connection> Connection::create(const QUuid &uuid, const QUuid &p
     return std::make_unique<Connection>(uuid, parentUuid, controlA, controlB, root);
 }
 
+QString Connection::debugName() {
+    return "Connection (" + find(root()->controls().sequence(), controlAUuid())->debugName() + " -> " +
+           find(root()->controls().sequence(), controlBUuid())->debugName() + ")";
+}
+
 void Connection::remove() {
     if (_wire.value()) (*_wire.value())->remove();
     ModelObject::remove();

--- a/editor/model/objects/Connection.h
+++ b/editor/model/objects/Connection.h
@@ -18,6 +18,8 @@ namespace AxiomModel {
         static std::unique_ptr<Connection> create(const QUuid &uuid, const QUuid &parentUuid, const QUuid &controlA,
                                                   const QUuid &controlB, ModelRoot *root);
 
+        QString debugName() override;
+
         NodeSurface *surface() const { return _surface; }
 
         const QUuid &controlAUuid() const { return _controlAUuid; }

--- a/editor/model/objects/Control.cpp
+++ b/editor/model/objects/Control.cpp
@@ -188,10 +188,6 @@ AxiomCommon::BoxedSequence<ModelObject *> Control::links() {
         AxiomCommon::boxSequence(AxiomCommon::staticCast<ModelObject *>(connections))}));
 }
 
-AxiomCommon::BoxedSequence<QUuid> Control::compileLinks() {
-    return AxiomCommon::boxSequence(AxiomCommon::once(surface()->node()->parentUuid()));
-}
-
 const std::optional<ControlCompileMeta> &Control::compileMeta() const {
     if (exposingUuid().isNull()) {
         return _compileMeta;
@@ -206,10 +202,6 @@ const std::optional<MaximFrontend::ControlPointers> &Control::runtimePointers() 
     } else {
         return find(root()->controls().sequence(), exposingUuid())->runtimePointers();
     }
-}
-
-void Control::remove() {
-    ModelObject::remove();
 }
 
 void Control::updateSinkPos() {

--- a/editor/model/objects/Control.h
+++ b/editor/model/objects/Control.h
@@ -108,8 +108,6 @@ namespace AxiomModel {
 
         AxiomCommon::BoxedSequence<ModelObject *> links() override;
 
-        AxiomCommon::BoxedSequence<QUuid> compileLinks() override;
-
         const std::optional<ControlCompileMeta> &compileMeta() const;
 
         const std::optional<MaximFrontend::ControlPointers> &runtimePointers() const;
@@ -121,8 +119,6 @@ namespace AxiomModel {
 
             restoreState();
         }
-
-        void remove() override;
 
     private:
         ControlSurface *_surface;

--- a/editor/model/objects/ControlSurface.cpp
+++ b/editor/model/objects/ControlSurface.cpp
@@ -29,6 +29,10 @@ std::unique_ptr<ControlSurface> ControlSurface::create(const QUuid &uuid, const 
     return std::make_unique<ControlSurface>(uuid, parentUuid, root);
 }
 
+QString ControlSurface::debugName() {
+    return "ControlSurface";
+}
+
 void ControlSurface::remove() {
     auto controls = findChildren(root()->controls().sequence(), uuid());
     while (!controls.empty()) {

--- a/editor/model/objects/ControlSurface.h
+++ b/editor/model/objects/ControlSurface.h
@@ -44,6 +44,8 @@ namespace AxiomModel {
 
         static QSizeF controlToNode(QSizeF p) { return {p.width() / 2., p.height() / 2.}; }
 
+        QString debugName() override;
+
         Node *node() const { return _node; }
 
         ChildCollection &controls() { return _controls; }

--- a/editor/model/objects/CustomNode.cpp
+++ b/editor/model/objects/CustomNode.cpp
@@ -42,17 +42,17 @@ void CustomNode::setCode(const QString &code) {
 
         if (runtimeId) {
             buildCode();
+            setDirty();
         }
     }
 }
 
 void CustomNode::doSetCodeAction(QString beforeCode, QString afterCode) {
-    std::vector<QUuid> compileItems;
     auto setCodeAction = SetCodeAction::create(uuid(), std::move(beforeCode), std::move(afterCode), {}, root());
-    setCodeAction->forward(true, compileItems);
+    setCodeAction->forward(true);
     updateControls(setCodeAction.get());
     root()->history().append(std::move(setCodeAction), false);
-    root()->applyCompile(compileItems);
+    root()->compileDirtyItems();
 }
 
 void CustomNode::setPanelOpen(bool panelOpen) {
@@ -172,8 +172,7 @@ void CustomNode::updateControls(SetCodeAction *action) {
 
             auto renameAction = RenameControlAction::create(tryClaimControl->uuid(), tryClaimControl->name(),
                                                             std::move(newControl.name), tryClaimControl->root());
-            std::vector<QUuid> dummy;
-            renameAction->forward(true, dummy);
+            renameAction->forward(true);
 
             assert(action);
             action->controlActions().push_back(std::move(renameAction));
@@ -191,8 +190,7 @@ void CustomNode::updateControls(SetCodeAction *action) {
     // remove any controls that weren't retained
     for (const auto &removedControl : removeControls) {
         auto deleteAction = DeleteObjectAction::create(removedControl->uuid(), root());
-        std::vector<QUuid> dummy;
-        deleteAction->forward(true, dummy);
+        deleteAction->forward(true);
 
         assert(action);
         action->controlActions().push_back(std::move(deleteAction));
@@ -204,8 +202,7 @@ void CustomNode::updateControls(SetCodeAction *action) {
     for (auto &newControl : unmatchedControls) {
         auto createAction = CreateControlAction::create((*controls().value())->uuid(), newControl.type,
                                                         std::move(newControl.name), newControl.meta.writtenTo, root());
-        std::vector<QUuid> dummy;
-        createAction->forward(true, dummy);
+        createAction->forward(true);
 
         assert(action);
         action->controlActions().push_back(std::move(createAction));

--- a/editor/model/objects/CustomNode.cpp
+++ b/editor/model/objects/CustomNode.cpp
@@ -35,6 +35,10 @@ std::unique_ptr<CustomNode> CustomNode::create(const QUuid &uuid, const QUuid &p
                                         panelOpen, panelHeight, root);
 }
 
+QString CustomNode::debugName() {
+    return "CustomNode '" + name() + "'";
+}
+
 void CustomNode::setCode(const QString &code) {
     if (_code != code) {
         _code = code;

--- a/editor/model/objects/CustomNode.h
+++ b/editor/model/objects/CustomNode.h
@@ -32,6 +32,8 @@ namespace AxiomModel {
 
         const QString &code() const { return _code; }
 
+        QString debugName() override;
+
         void setCode(const QString &code);
 
         void doSetCodeAction(QString beforeCode, QString afterCode);

--- a/editor/model/objects/ExtractControl.cpp
+++ b/editor/model/objects/ExtractControl.cpp
@@ -33,6 +33,10 @@ std::unique_ptr<ExtractControl> ExtractControl::create(const QUuid &uuid, const 
                                             exposerUuid, exposingUuid, wireType, activeSlots, root);
 }
 
+QString ExtractControl::debugName() {
+    return "ExtractControl '" + name() + "'";
+}
+
 void ExtractControl::setActiveSlots(AxiomModel::ExtractControl::ActiveSlotFlags activeSlots) {
     if (activeSlots != _activeSlots) {
         _activeSlots = activeSlots;

--- a/editor/model/objects/ExtractControl.h
+++ b/editor/model/objects/ExtractControl.h
@@ -21,6 +21,8 @@ namespace AxiomModel {
                                                       ConnectionWire::WireType wireType, ActiveSlotFlags activeSlots,
                                                       ModelRoot *root);
 
+        QString debugName() override;
+
         ActiveSlotFlags activeSlots() const { return _activeSlots; }
 
         void setActiveSlots(ActiveSlotFlags activeSlots);

--- a/editor/model/objects/GraphControl.cpp
+++ b/editor/model/objects/GraphControl.cpp
@@ -18,6 +18,10 @@ std::unique_ptr<GraphControl> GraphControl::create(const QUuid &uuid, const QUui
                                           exposingUuid, std::move(savedState), root);
 }
 
+QString GraphControl::debugName() {
+    return "GraphControl ' " + name() + "'";
+}
+
 void GraphControl::doRuntimeUpdate() {
     // hash the current state so we can compare it
     auto currentState = getCurveState();

--- a/editor/model/objects/GraphControl.h
+++ b/editor/model/objects/GraphControl.h
@@ -36,6 +36,8 @@ namespace AxiomModel {
                                                     std::unique_ptr<GraphControlCurveState> savedState,
                                                     ModelRoot *root);
 
+        QString debugName() override;
+
         void doRuntimeUpdate() override;
 
         GraphControlTimeState *getTimeState() const;

--- a/editor/model/objects/GroupNode.cpp
+++ b/editor/model/objects/GroupNode.cpp
@@ -19,6 +19,10 @@ std::unique_ptr<GroupNode> GroupNode::create(const QUuid &uuid, const QUuid &par
     return std::make_unique<GroupNode>(uuid, parentUuid, pos, size, selected, name, controlsUuid, innerUuid, root);
 }
 
+QString GroupNode::debugName() {
+    return "GroupNode '" + name() + "'";
+}
+
 void GroupNode::attachRuntime(MaximCompiler::Runtime *runtime, MaximCompiler::Transaction *transaction) {
     nodes().then([runtime, transaction](NodeSurface *const &surface) { surface->attachRuntime(runtime, transaction); });
 }

--- a/editor/model/objects/GroupNode.h
+++ b/editor/model/objects/GroupNode.h
@@ -17,6 +17,8 @@ namespace AxiomModel {
                                                  bool selected, QString name, const QUuid &controlsUuid,
                                                  const QUuid &innerUuid, ModelRoot *root);
 
+        QString debugName() override;
+
         AxiomCommon::Promise<GroupSurface *> &nodes() { return *_nodes; }
 
         const AxiomCommon::Promise<GroupSurface *> &nodes() const { return *_nodes; }

--- a/editor/model/objects/GroupSurface.cpp
+++ b/editor/model/objects/GroupSurface.cpp
@@ -23,6 +23,10 @@ QString GroupSurface::name() {
     return _node->name();
 }
 
+QString GroupSurface::debugName() {
+    return "GroupSurface";
+}
+
 void GroupSurface::attachRuntime(MaximCompiler::Runtime *runtime, MaximCompiler::Transaction *transaction) {
     if (runtime) {
         runtimeId = runtime->nextId();

--- a/editor/model/objects/GroupSurface.cpp
+++ b/editor/model/objects/GroupSurface.cpp
@@ -23,11 +23,6 @@ QString GroupSurface::name() {
     return _node->name();
 }
 
-AxiomCommon::BoxedSequence<QUuid> GroupSurface::compileLinks() {
-    return AxiomCommon::boxSequence(AxiomCommon::flatten(std::array<AxiomCommon::BoxedSequence<QUuid>, 2>{
-        AxiomCommon::boxSequence(AxiomCommon::once(node()->surface()->uuid())), node()->surface()->compileLinks()}));
-}
-
 void GroupSurface::attachRuntime(MaximCompiler::Runtime *runtime, MaximCompiler::Transaction *transaction) {
     if (runtime) {
         runtimeId = runtime->nextId();

--- a/editor/model/objects/GroupSurface.h
+++ b/editor/model/objects/GroupSurface.h
@@ -41,8 +41,6 @@ namespace AxiomModel {
 
         uint64_t getRuntimeId() override { return runtimeId; }
 
-        AxiomCommon::BoxedSequence<QUuid> compileLinks() override;
-
         void attachRuntime(MaximCompiler::Runtime *runtime, MaximCompiler::Transaction *transaction) override;
 
         const std::optional<GroupSurfaceCompileMeta> &compileMeta() const { return _compileMeta; }

--- a/editor/model/objects/GroupSurface.h
+++ b/editor/model/objects/GroupSurface.h
@@ -33,6 +33,8 @@ namespace AxiomModel {
 
         QString name() override;
 
+        QString debugName() override;
+
         bool canExposeControl() const override { return true; }
 
         bool canHavePortals() const override { return false; }

--- a/editor/model/objects/MidiControl.cpp
+++ b/editor/model/objects/MidiControl.cpp
@@ -14,3 +14,7 @@ std::unique_ptr<MidiControl> MidiControl::create(const QUuid &uuid, const QUuid 
     return std::make_unique<MidiControl>(uuid, parentUuid, pos, size, selected, std::move(name), showName, exposerUuid,
                                          exposingUuid, root);
 }
+
+QString MidiControl::debugName() {
+    return "MidiControl '" + name() + "'";
+}

--- a/editor/model/objects/MidiControl.h
+++ b/editor/model/objects/MidiControl.h
@@ -17,6 +17,8 @@ namespace AxiomModel {
                                                    bool selected, QString name, bool showName, const QUuid &exposerUuid,
                                                    const QUuid &exposingUuid, ModelRoot *root);
 
+        QString debugName() override;
+
         void doRuntimeUpdate() override {}
     };
 }

--- a/editor/model/objects/NodeSurface.cpp
+++ b/editor/model/objects/NodeSurface.cpp
@@ -119,6 +119,9 @@ void NodeSurface::nodeAdded(AxiomModel::Node *node) {
     node->controls().then([this](ControlSurface *surface) {
         surface->controls().events().itemAdded().connect(this, &NodeSurface::setDirty);
         surface->controls().events().itemRemoved().connect(this, &NodeSurface::setDirty);
+
+        surface->controls().events().itemAdded().connect(
+            [this](Control *control) { control->exposerUuidChanged.connect(this, &NodeSurface::setDirty); });
     });
 
     if (_runtime) {

--- a/editor/model/objects/NodeSurface.h
+++ b/editor/model/objects/NodeSurface.h
@@ -83,6 +83,6 @@ namespace AxiomModel {
 
         MaximCompiler::Runtime *_runtime = nullptr;
 
-        void nodeAdded(Node *node) const;
+        void nodeAdded(Node *node);
     };
 }

--- a/editor/model/objects/NumControl.cpp
+++ b/editor/model/objects/NumControl.cpp
@@ -19,6 +19,10 @@ std::unique_ptr<NumControl> NumControl::create(const QUuid &uuid, const QUuid &p
                                         exposingUuid, displayMode, minValue, maxValue, step, value, root);
 }
 
+QString NumControl::debugName() {
+    return "NumControl '" + name() + "'";
+}
+
 void NumControl::setDisplayMode(AxiomModel::NumControl::DisplayMode displayMode) {
     if (displayMode != _displayMode) {
         _displayMode = displayMode;

--- a/editor/model/objects/NumControl.h
+++ b/editor/model/objects/NumControl.h
@@ -23,6 +23,8 @@ namespace AxiomModel {
                                                   const QUuid &exposingUuid, DisplayMode displayMode, float minValue,
                                                   float maxValue, uint32_t step, NumValue value, ModelRoot *root);
 
+        QString debugName() override;
+
         DisplayMode displayMode() const { return _displayMode; }
 
         void setDisplayMode(DisplayMode displayMode);

--- a/editor/model/objects/PortalControl.cpp
+++ b/editor/model/objects/PortalControl.cpp
@@ -33,6 +33,10 @@ std::unique_ptr<PortalControl> PortalControl::create(const QUuid &uuid, const QU
                                            exposerUuid, exposingUuid, wireType, portalType, portalId, root);
 }
 
+QString PortalControl::debugName() {
+    return "PortalControl '" + name() + "'";
+}
+
 void PortalControl::restoreState() {
     _needsLabelUpdate = true;
     labelWillChange();

--- a/editor/model/objects/PortalControl.h
+++ b/editor/model/objects/PortalControl.h
@@ -21,6 +21,8 @@ namespace AxiomModel {
                                                      ConnectionWire::WireType wireType, PortalType portalType,
                                                      uint64_t portalId, ModelRoot *root);
 
+        QString debugName() override;
+
         bool isMovable() const override { return false; }
 
         PortalType portalType() const { return _portalType; }

--- a/editor/model/objects/PortalNode.cpp
+++ b/editor/model/objects/PortalNode.cpp
@@ -14,3 +14,7 @@ std::unique_ptr<PortalNode> PortalNode::create(const QUuid &uuid, const QUuid &p
                                                AxiomModel::ModelRoot *root) {
     return std::make_unique<PortalNode>(uuid, parentUuid, pos, size, selected, std::move(name), controlsUuid, root);
 }
+
+QString PortalNode::debugName() {
+    return "PortalNode '" + name() + "'";
+}

--- a/editor/model/objects/PortalNode.h
+++ b/editor/model/objects/PortalNode.h
@@ -13,6 +13,8 @@ namespace AxiomModel {
                                                   bool selected, QString name, const QUuid &controlsUuid,
                                                   ModelRoot *root);
 
+        QString debugName() override;
+
         bool isResizable() const override { return false; }
 
         bool isCopyable() const override { return false; }

--- a/editor/model/objects/RootSurface.cpp
+++ b/editor/model/objects/RootSurface.cpp
@@ -4,3 +4,7 @@ using namespace AxiomModel;
 
 RootSurface::RootSurface(const QUuid &uuid, QPointF pan, float zoom, size_t nextPortalId, AxiomModel::ModelRoot *root)
     : NodeSurface(uuid, QUuid(), pan, zoom, root), _nextPortalId(nextPortalId) {}
+
+QString RootSurface::debugName() {
+    return "RootSurface";
+}

--- a/editor/model/objects/RootSurface.h
+++ b/editor/model/objects/RootSurface.h
@@ -31,6 +31,8 @@ namespace AxiomModel {
 
         QString name() override { return "Root"; }
 
+        QString debugName() override;
+
         bool canExposeControl() const override { return false; }
 
         bool canHavePortals() const override { return true; }

--- a/editor/model/serialize/HistorySerializer.cpp
+++ b/editor/model/serialize/HistorySerializer.cpp
@@ -47,8 +47,7 @@ void HistorySerializer::serialize(const AxiomModel::HistoryList &history, QDataS
     }
 }
 
-HistoryList HistorySerializer::deserialize(QDataStream &stream, uint32_t version, ModelRoot *root,
-                                           HistoryList::CompileApplyer applyer) {
+HistoryList HistorySerializer::deserialize(QDataStream &stream, uint32_t version, ModelRoot *root) {
     uint32_t stackPos;
     stream >> stackPos;
     uint32_t stackSize;
@@ -63,7 +62,7 @@ HistoryList HistorySerializer::deserialize(QDataStream &stream, uint32_t version
         stack.push_back(deserializeAction(actionStream, version, root));
     }
 
-    return HistoryList(stackPos, std::move(stack), std::move(applyer));
+    return HistoryList(stackPos, std::move(stack));
 }
 
 void HistorySerializer::serializeAction(AxiomModel::Action *action, QDataStream &stream) {

--- a/editor/model/serialize/HistorySerializer.h
+++ b/editor/model/serialize/HistorySerializer.h
@@ -36,8 +36,7 @@ namespace AxiomModel {
     namespace HistorySerializer {
         void serialize(const HistoryList &history, QDataStream &stream);
 
-        HistoryList deserialize(QDataStream &stream, uint32_t version, ModelRoot *root,
-                                HistoryList::CompileApplyer applyer);
+        HistoryList deserialize(QDataStream &stream, uint32_t version, ModelRoot *root);
 
         void serializeAction(Action *action, QDataStream &stream);
 

--- a/editor/model/serialize/ModelObjectSerializer.cpp
+++ b/editor/model/serialize/ModelObjectSerializer.cpp
@@ -51,8 +51,7 @@ std::unique_ptr<ModelRoot> ModelObjectSerializer::deserializeRoot(QDataStream &s
     IdentityReferenceMapper ref;
     deserializeChunk(stream, version, modelRoot.get(), QUuid(), &ref);
     if (includeHistory) {
-        modelRoot->history() =
-            HistorySerializer::deserialize(stream, version, modelRoot.get(), std::move(modelRoot->history().applyer()));
+        modelRoot->setHistory(HistorySerializer::deserialize(stream, version, modelRoot.get()));
     }
     return modelRoot;
 }

--- a/editor/widgets/surface/NodeSurfaceView.cpp
+++ b/editor/widgets/surface/NodeSurfaceView.cpp
@@ -128,9 +128,6 @@ void NodeSurfaceView::dragEnterEvent(QDragEnterEvent *event) {
     auto action = PasteBufferAction::create(surface->uuid(), std::move(data), nodePos, surface->root());
 
     action->forward(true);
-    MaximCompiler::Transaction transaction;
-    surface->root()->applyDirtyItemsTo(&transaction);
-    dragAndDropTransaction = std::move(transaction);
 
     std::vector<std::unique_ptr<Action>> actions;
     actions.push_back(std::move(action));
@@ -167,8 +164,6 @@ void NodeSurfaceView::dropEvent(QDropEvent *event) {
     }
 
     surface->root()->history().append(std::move(dragAndDropAction), false);
-    surface->root()->applyTransaction(std::move(*dragAndDropTransaction));
-    dragAndDropTransaction = std::nullopt;
 }
 
 void NodeSurfaceView::focusInEvent(QFocusEvent *event) {

--- a/editor/widgets/surface/NodeSurfaceView.cpp
+++ b/editor/widgets/surface/NodeSurfaceView.cpp
@@ -127,10 +127,9 @@ void NodeSurfaceView::dragEnterEvent(QDragEnterEvent *event) {
     auto data = event->mimeData()->data("application/axiom-partial-surface");
     auto action = PasteBufferAction::create(surface->uuid(), std::move(data), nodePos, surface->root());
 
-    std::vector<QUuid> compileItems;
-    action->forward(true, compileItems);
+    action->forward(true);
     MaximCompiler::Transaction transaction;
-    surface->root()->applyItemsTo(compileItems, &transaction);
+    surface->root()->applyDirtyItemsTo(&transaction);
     dragAndDropTransaction = std::move(transaction);
 
     std::vector<std::unique_ptr<Action>> actions;
@@ -149,8 +148,7 @@ void NodeSurfaceView::dragMoveEvent(QDragMoveEvent *event) {
 
 void NodeSurfaceView::dragLeaveEvent(QDragLeaveEvent *event) {
     surface->grid().finishDragging();
-    std::vector<QUuid> dummy;
-    dragAndDropAction->backward(dummy);
+    dragAndDropAction->backward();
     dragAndDropAction.reset();
 }
 

--- a/editor/widgets/surface/NodeSurfaceView.h
+++ b/editor/widgets/surface/NodeSurfaceView.h
@@ -72,7 +72,6 @@ namespace AxiomGui {
         QPointF startPan;
         float lastScale = 1;
         std::unique_ptr<AxiomModel::CompositeAction> dragAndDropAction;
-        std::optional<MaximCompiler::Transaction> dragAndDropTransaction;
 
         static float zoomToScale(float zoom);
 


### PR DESCRIPTION
Fixes a bunch of crashes related to the runtime not being kept up-to-date properly, by using a dirty/clean system instead of the adhoc "append the items to compile to this list" system. ModelObjects set themselves as dirty internally, normally though events (e.g. see NodeSurface). This means all of the things that make an object dirty can be seen by looking at that object, instead of needing to look everywhere.