### PR TITLE
Edits to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,19 @@ cmake ../path/to/source -DAXIOM_STATIC_LINK=ON -DVST2_SDK_ROOT=/path/to/vst/sdk
 
 CMake will setup files necessary for building. If this fails, make sure you've got Cargo, Qt, LLVM, and the VST SDK installed correctly. Once complete, you can choose which backend to build:
 
-**VST2 Instrument**
+###VST2 Instrument & VST2 Effect
 
-* To build the VST2 instrument backend, use the following command. You will need to specify a path to the VST2 SDK. You can also build the VST2 effect with the `axiom_vst2_effect` target.
-
+* To build the VST2 instrument backend, use the following command. You will need to specify a path to the VST2 SDK. 
 ```
 cmake --build ./ --target axiom_vst2_instrument
 ```
 
-**Standalone**
+* You can also build the VST2 effect with the `axiom_vst2_effect` target.
+```
+cmake --build ./ --target axiom_vst2_effect
+```
+
+###Standalone
 
 * To build the standalone version as an executable, use the following command. In order to enable audio output in this version, the PortAudio library must be installed. You can still use the standalone editor without it, the graph just won't be simulated.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ cmake ../path/to/source -DAXIOM_STATIC_LINK=ON -DVST2_SDK_ROOT=/path/to/vst/sdk
 
 CMake will setup files necessary for building. If this fails, make sure you've got Cargo, Qt, LLVM, and the VST SDK installed correctly. Once complete, you can choose which backend to build:
 
-###VST2 Instrument & VST2 Effect
+### VST2 Instrument & VST2 Effect
 
 * To build the VST2 instrument backend, use the following command. You will need to specify a path to the VST2 SDK. 
 ```
@@ -55,7 +55,7 @@ cmake --build ./ --target axiom_vst2_instrument
 cmake --build ./ --target axiom_vst2_effect
 ```
 
-###Standalone
+### Standalone
 
 * To build the standalone version as an executable, use the following command. In order to enable audio output in this version, the PortAudio library must be installed. You can still use the standalone editor without it, the graph just won't be simulated.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Axiom is an extremely flexible node-based realtime audio synthesizer. It was ori
 Features:
 
  - Musician-friendly (ie knobs and sliders) interface
- - Highly customizable and flexible through a node editor and custom scripting language, named Maxim
+ - Highly customizable and flexible through a node editor and Maxim, a custom scripting language
  - Export to replayer with no dependencies (not even the standard library)
  - Use any DAW with VSTi support for note editing and automation
 
@@ -43,13 +43,17 @@ cmake ../path/to/source -DAXIOM_STATIC_LINK=ON -DVST2_SDK_ROOT=/path/to/vst/sdk
 
 CMake will setup files necessary for building. If this fails, make sure you've got Cargo, Qt, LLVM, and the VST SDK installed correctly. Once complete, you can choose which backend to build:
 
-To build the VST2 instrument backend, use the following command. You will need to specify a path to the VST2 SDK. You can also build the VST2 effect with the `axiom_vst2_effect` target.
+**VST2 Instrument**
+
+* To build the VST2 instrument backend, use the following command. You will need to specify a path to the VST2 SDK. You can also build the VST2 effect with the `axiom_vst2_effect` target.
 
 ```
 cmake --build ./ --target axiom_vst2_instrument
 ```
 
-To build the standalone version as an executable, use the following command. In order to enable audio output in this version, the PortAudio library must be installed. You can still use the standalone editor without it, the graph just won't be simulated.
+**Standalone**
+
+* To build the standalone version as an executable, use the following command. In order to enable audio output in this version, the PortAudio library must be installed. You can still use the standalone editor without it, the graph just won't be simulated.
 
 ```
 cmake --build ./ --target axiom_standalone


### PR DESCRIPTION
Edited the "highly customizable and flexible..." bullet point of features section. Changed "...a node editor and custom scripting language, named Maxim" to "...a node editor and Maxim, a custom scripting language." The edit clarifies that it's only the custom scripting language that is called Maxim (if that is what you meant).

Edited presentation of instructions in building backend. The two separate instructions are in bullets and are each preceded by a bolded title . It is now clear to the reader that there are two options in building backends.

Fixes #143 