### PR TITLE
Static build on mac building but not running

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ If you want to build it statically-linked, pass the `AXIOM_STATIC_LINK` flag:
 ```
 cmake ../path/to/source -DAXIOM_STATIC_LINK=ON -DVST2_SDK_ROOT=/path/to/vst/sdk
 ```
+For static linking on macOS [compile Qt statically](http://doc.qt.io/qt-5/osx-deployment.html) and install HarfBuzz, libpng and PCRE2:
+```
+brew install harfbuzz libpng pcre2
+```
 
 CMake will setup files necessary for building. If this fails, make sure you've got Cargo, Qt, LLVM, and the VST SDK installed correctly. Once complete, you can choose which backend to build:
 

--- a/editor/CMakeLists.txt
+++ b/editor/CMakeLists.txt
@@ -4,7 +4,16 @@ if (AXIOM_STATIC_LINK)
     set(Qt5_USE_STATIC_LIBS ON)
     set(Qt5_USE_STATIC_RUNTIME ON)
     add_definitions(-DAXIOM_STATIC_BUILD=1)
-    set(AXIOM_LINK_FLAGS -static -static-libgcc -static-libstdc++)
+
+    find_library(OpenGL_LIBRARY OpenGL)
+    set(STATIC_LIBS ${OpenGL_LIBRARY})
+
+    if (APPLE)
+        set(AXIOM_LINK_FLAGS "")
+    else ()
+        set(AXIOM_LINK_FLAGS -static -static-libgcc -static-libstdc++)
+    endif ()
+
 else ()
     set(AXIOM_LINK_FLAGS "")
 endif ()
@@ -36,6 +45,39 @@ add_library(axiom_editor
         backend/AudioConfiguration.h backend/AudioConfiguration.cpp
         backend/PersistentParameters.h)
 target_link_libraries(axiom_editor axiom_widgets axiom_model axiom_common maxim_compiler Qt5::Widgets)
+if (AXIOM_STATIC_LINK)
+    if (APPLE)
+        FIND_PACKAGE(PNG REQUIRED)
+        list(APPEND STATIC_LIBS PNG::PNG)
+
+        FIND_PACKAGE(harfbuzz REQUIRED)
+        list(APPEND STATIC_LIBS harfbuzz::harfbuzz)
+
+        list(APPEND STATIC_LIBS /usr/local/Cellar/pcre2/10.32/lib/libpcre2-16.a)
+
+        find_library(QTFREETYPE NAMES qtfreetype)
+        set_target_properties(Qt5::Core PROPERTIES INTERFACE_LINK_LIBRARIES "${QTFREETYPE}")
+
+        list(APPEND STATIC_LIBS /usr/local/Qt-5.11.2/lib/libQt5AccessibilitySupport.a
+                                /usr/local/Qt-5.11.2/lib/libQt5ClipboardSupport.a
+                                /usr/local/Qt-5.11.2/lib/libQt5FontDatabaseSupport.a
+                                /usr/local/Qt-5.11.2/lib/libQt5GraphicsSupport.a
+                                /usr/local/Qt-5.11.2/lib/libQt5ThemeSupport.a)
+
+
+        find_package(Qt5Svg REQUIRED)
+        find_package(Qt5PrintSupport REQUIRED)
+        list(APPEND AXIOM_LINK_FLAGS -lcups) # CUPS printer interface
+        find_package(Qt5OpenGL REQUIRED)
+        qt5_use_modules(axiom_editor PrintSupport)
+        list(APPEND STATIC_LIBS Qt5::Core Qt5::QCocoaIntegrationPlugin
+                                Qt5::QCocoaPrinterSupportPlugin Qt5::OpenGL Qt5::Svg)
+        target_link_libraries(axiom_editor "-framework Carbon" "-framework CoreFoundation" "-framework CoreServices" "-framework CoreText" "-framework Cocoa" "-framework QuartzCore" "-framework IOKit" "-framework Security")
+
+        target_link_libraries(axiom_editor ${STATIC_LIBS})
+
+    endif ()
+endif ()
 
 add_subdirectory(backend)
 


### PR DESCRIPTION
After some wrangling Axiom is building statically on my Mac but when it runs I get:
```
"/Users/user/Bounce/groove-axiom/cmake-build-static-debug/editor/backend/standalone/Axiom Standalone.app/Contents/MacOS/Axiom Standalone"
2018-11-14 12:37:39.243647+0000 Axiom Standalone[51624:456889] ASSERT failure in QVariant: "Trying to construct an unknown type", file kernel/qvariant.cpp, line 1136
Signal: SIGABRT (signal SIGABRT)
```
Which occurs when QVariant::create is called with type QVariant::Brush (66).
In order to get static linking working I referred to this:
http://doc.qt.io/qt-5/osx-deployment.html
But when not using QMake it seems that many libraries and macOS frameworks must be linked in CMake.
Any ideas about what might be causing the current runtime error would be useful. A possible clue is that HandlersManager::registerHandler in qvariant.cpp is never called, so perhaps the Brush type is never being registered for some reason?